### PR TITLE
Fix usage counter query for current month

### DIFF
--- a/lib/data/usage_repo.dart
+++ b/lib/data/usage_repo.dart
@@ -6,14 +6,15 @@ class UsageRepo {
 
   Future<int> currentMonthCount(String kind) async {
     final uid = _sb.auth.currentUser!.id;
-    final startOfMonth =
-        DateTime(DateTime.now().year, DateTime.now().month, 1).toIso8601String();
+    final startOfMonth = DateTime(DateTime.now().year, DateTime.now().month, 1)
+        .toIso8601String()
+        .substring(0, 10);
     final rows = await _sb
         .from('usage_counters')
         .select('count')
         .eq('user_id', uid)
         .eq('kind', kind)
-        .gte('period_start', startOfMonth)
+        .eq('period_start', startOfMonth)
         .limit(1);
     if (rows.isEmpty) return 0;
     return (rows.first['count'] as num).toInt();


### PR DESCRIPTION
## Summary
- Correct month usage query to match stored date format for accurate counts

## Testing
- `flutter test` *(command not found: flutter)*
- `dart test` *(command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_689b23bd8ac8832f9d5fcc19b218cb96