### PR TITLE
Revamp auth screens with modern layout

### DIFF
--- a/lib/features/auth/presentation/sign_in_screen.dart
+++ b/lib/features/auth/presentation/sign_in_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as sb;
+
 import '../../../shared/services/snack.dart';
 
 class SignInScreen extends StatefulWidget {
@@ -15,6 +16,7 @@ class _SignInScreenState extends State<SignInScreen> {
   final _email = TextEditingController();
   final _password = TextEditingController();
   bool _loading = false;
+  final _sb = sb.Supabase.instance.client;
 
   @override
   void dispose() {
@@ -27,13 +29,13 @@ class _SignInScreenState extends State<SignInScreen> {
     if (!_form.currentState!.validate()) return;
     setState(() => _loading = true);
     try {
-      await Supabase.instance.client.auth.signInWithPassword(
+      await _sb.auth.signInWithPassword(
         email: _email.text.trim(),
         password: _password.text,
       );
       if (!mounted) return;
       context.go('/post-register');
-    } on AuthException catch (e) {
+    } on sb.AuthException catch (e) {
       showSnack(context, e.message);
     } catch (_) {
       showSnack(context, 'Something went wrong');
@@ -42,39 +44,101 @@ class _SignInScreenState extends State<SignInScreen> {
     }
   }
 
+  Future<void> _signInWithGoogle() async {
+    setState(() => _loading = true);
+    try {
+      await _sb.auth.signInWithOAuth(sb.OAuthProvider.google);
+      if (!mounted) return;
+      context.go('/post-register');
+    } on sb.AuthException catch (e) {
+      showSnack(context, e.message);
+    } catch (_) {
+      showSnack(context, 'Google sign-in failed. Please try again.');
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Sign in')),
-      body: Form(
-        key: _form,
-        child: ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
-            TextFormField(
-              controller: _email,
-              decoration: const InputDecoration(labelText: 'Email'),
-              keyboardType: TextInputType.emailAddress,
-              validator: (v) => (v == null || !v.contains('@')) ? 'Enter a valid email' : null,
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Form(
+              key: _form,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text('Welcome back',
+                      style: theme.textTheme.headlineSmall
+                          ?.copyWith(fontWeight: FontWeight.w700)),
+                  const SizedBox(height: 8),
+                  Text('Sign in with Google or use your email.',
+                      style: theme.textTheme.bodyMedium),
+                  const SizedBox(height: 24),
+                  SizedBox(
+                    height: 48,
+                    child: OutlinedButton.icon(
+                      onPressed: _loading ? null : _signInWithGoogle,
+                      icon: const Icon(Icons.g_mobiledata),
+                      label: const Text('Continue with Google'),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    children: const [
+                      Expanded(child: Divider()),
+                      Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 12),
+                        child: Text('or with email'),
+                      ),
+                      Expanded(child: Divider()),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: _email,
+                    decoration: const InputDecoration(
+                      labelText: 'Email',
+                      border: OutlineInputBorder(),
+                    ),
+                    keyboardType: TextInputType.emailAddress,
+                    validator: (v) =>
+                        (v == null || !v.contains('@')) ? 'Enter a valid email' : null,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _password,
+                    decoration: const InputDecoration(
+                      labelText: 'Password',
+                      border: OutlineInputBorder(),
+                    ),
+                    obscureText: true,
+                    validator: (v) =>
+                        (v == null || v.length < 8) ? 'Min 8 characters' : null,
+                  ),
+                  const SizedBox(height: 20),
+                  SizedBox(
+                    height: 48,
+                    child: FilledButton(
+                      onPressed: _loading ? null : _submit,
+                      child: _loading
+                          ? const CircularProgressIndicator()
+                          : const Text('Continue'),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  TextButton(
+                    onPressed: () => context.go('/register/step1'),
+                    child: const Text('Create an account'),
+                  )
+                ],
+              ),
             ),
-            const SizedBox(height: 12),
-            TextFormField(
-              controller: _password,
-              decoration: const InputDecoration(labelText: 'Password'),
-              obscureText: true,
-              validator: (v) => (v == null || v.length < 8) ? 'Min 8 characters' : null,
-            ),
-            const SizedBox(height: 16),
-            FilledButton(
-              onPressed: _loading ? null : _submit,
-              child: _loading ? const CircularProgressIndicator() : const Text('Continue'),
-            ),
-            const SizedBox(height: 12),
-            TextButton(
-              onPressed: () => context.go('/register/step1'),
-              child: const Text('Create an account'),
-            )
-          ],
+          ),
         ),
       ),
     );

--- a/lib/features/auth/presentation/signup_screen.dart
+++ b/lib/features/auth/presentation/signup_screen.dart
@@ -305,31 +305,33 @@ class _SignUpScreenState extends State<SignUpScreen> {
           );
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Create your account')),
-      body: AbsorbPointer(
-        absorbing: _busy,
-        child: Stack(
-          children: [
-            AnimatedOpacity(
-              duration: const Duration(milliseconds: 200),
-              opacity: _busy ? 0.5 : 1,
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.all(16),
-                child: Center(
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 520),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        // Info banner (optional)
-                        banner,
-                        if (_infoBanner != null) const SizedBox(height: 8),
+      body: SafeArea(
+        child: AbsorbPointer(
+          absorbing: _busy,
+          child: Stack(
+            children: [
+              AnimatedOpacity(
+                duration: const Duration(milliseconds: 200),
+                opacity: _busy ? 0.5 : 1,
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.all(24),
+                  child: Center(
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 520),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          // Info banner (optional)
+                          banner,
+                          if (_infoBanner != null) const SizedBox(height: 8),
 
-                        Text('Welcome to EFTAR',
-                            style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700)),
-                        const SizedBox(height: 8),
-                        Text('Join with Google or continue with email.', style: theme.textTheme.bodyMedium),
-                        const SizedBox(height: 20),
+                          Text('Create your account',
+                              style: theme.textTheme.headlineSmall
+                                  ?.copyWith(fontWeight: FontWeight.w700)),
+                          const SizedBox(height: 8),
+                          Text('Join with Google or continue with email.',
+                              style: theme.textTheme.bodyMedium),
+                          const SizedBox(height: 20),
 
                         SizedBox(
                           height: 48,


### PR DESCRIPTION
## Summary
- Modernize sign-in with centered layout, Google auth button, and styled form fields
- Refresh sign-up flow using SafeArea, updated heading, and consistent padding

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b24d264d4832f92a6f8ce4410de93